### PR TITLE
Cleaner output channel, and better error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to the "kotlin-formatter" extension will be documented in th
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [Unreleased]
+## [0.0.3] - 2021-10-01
+### Added
+- Find and apply .editorconfig from parent directory - [@RozPierog #4](https://github.com/cstefFlexin/kotlin-formatter/pull/4)
+### Changed
+- Output channel cleanup - [@RozPierog #5](https://github.com/cstefFlexin/kotlin-formatter/pull/5)
+  - tags for messeges
+  - errors print only relevant info
+  - no priniting ouptut when formatting was a success
+- `Format Kotlin` command now uses same error reporting as file formatting - [@RozPierog #5](https://github.com/cstefFlexin/kotlin-formatter/pull/5)
+- output channel opens up to show full error if there was an issue with  formatting - [@RozPierog #5](https://github.com/cstefFlexin/kotlin-formatter/pull/5)
+## [0.0.2] - 2021-09-11
+### Changed
+- New icon
 
+## [0.0.1] - 2021-09-11
+### Added
 - Initial release
+
+

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "kotlin-formatter",
     "displayName": "Kotlin Formatter",
     "description": "Format your Kotlin code easily",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "engines": {
         "vscode": "^1.60.0"
     },


### PR DESCRIPTION
fixes #3 

I got rid of doubled information in output channel

```typescript
output.appendLine(`${err}`);
output.appendLine(stderr);
```
did basically the same thing

---
shorten other outputs to easy to understand bits. 

Example of the new output in the channel 

```
[INFO]: Enabled Kotlin-Formatter
[INFO]: Found editorconfig file at: /<path>/.editorconfig
[INFO]: Formatting file: /<path>/MainActivity.kt
[ERROR]: <stdin>:42:1: Exceeded max line length (100) (cannot be auto-corrected)
<stdin>:43:1: Exceeded max line length (100) (cannot be auto-corrected)
```
---
- `kotlin-formatter.formatKotlin` wrapped in a try catch to get rid of error dialog and moved error handling to output channel

- Show output channel on error (without taking focus) for easier checking what couldn't be auto-corrected/what failed (if you do not agree with that change let me know, maybe I'll try to move it into some setting)