### PR TITLE
Check for .editorconfig outside immediate parent

### DIFF
--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -32,9 +32,15 @@ const getFiles = (dir: string): string[] => {
 
 const findEditorConfig = (document: vscode.TextDocument): string | null => {
   const documentPath = document.uri.fsPath;
-  var testedFolder = path.dirname(documentPath);
-  const files = getFiles(testedFolder);
-  const editorConfig = files.find((e) => /\.editorconfig/.test(e));
+  let testedFolder = documentPath;
+  let editorConfig;
+  while (!editorConfig) {
+    const newFolder = path.dirname(testedFolder);
+    if (newFolder === testedFolder) { break; }
+    testedFolder = newFolder;
+    const files = getFiles(testedFolder);
+    editorConfig = files.find((e) => /\.editorconfig/.test(e));
+  }
   if (editorConfig) {
     return editorConfig;
   }

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -21,44 +21,52 @@ const checkIfKTlintExist = platformSelect({
   },
 });
 
-const getFiles = (dir: string): string[] => {
+const getFiles = (dir: string, recursive = false): string[] => {
   const dirents = fs.readdirSync(dir, { withFileTypes: true });
-  const files = dirents.map((dirent) => {
-    const res = path.resolve(dir, dirent.name);
-    return dirent.isDirectory() ? '' : res;
-  });
-  return Array.prototype.concat(...files).filter(v => v !== '');
+  const files = dirents
+    .filter(dirent => dirent.isFile() || (recursive && dirent.isDirectory()))
+    .map(dirent => {
+      const res = path.resolve(dir, dirent.name);
+      return (recursive && dirent.isDirectory()) ? getFiles(res, recursive) : res;
+    });
+  return Array.prototype.concat(...files);
+};
+
+const findInFolder = (dir: string, filename: string, recursive = false) => {
+  try {
+    const files = getFiles(dir, recursive);
+    const file = files.find((e) => e.endsWith(`/${filename}`));
+    if (file) {
+      fs.accessSync(file, fs.constants.R_OK);
+      return file;
+    }
+  } catch (err: any) {
+    if (err.code !== 'EPERM' && err.code !== 'EACCES') {
+      throw err;
+    }
+  }
+
+  return null;
 };
 
 const findEditorConfig = (document: vscode.TextDocument): string | null => {
   const documentPath = document.uri.fsPath;
-  let testedFolder = documentPath;
-  let editorConfig: string | undefined;
+  let testedFolder = path.dirname(documentPath);
+  let editorConfig = findInFolder(testedFolder, '.editorconfig', true);
   while (!editorConfig) {
     const newFolder = path.dirname(testedFolder);
+    // detect fs root directory to avoid an eternal loop, since `dirname('/') = '/'`
     if (newFolder === testedFolder) {
       break;
     }
     testedFolder = newFolder;
-    try {
-      const files = getFiles(testedFolder);
-      const potentialEditorConfig = files.find((e) => /\.editorconfig/.test(e));
-      if (potentialEditorConfig) {
-        fs.accessSync(potentialEditorConfig, fs.constants.R_OK);
-        editorConfig = potentialEditorConfig;
-      }
-    } catch (err: any) {
-      if (err.code === 'EPERM' || err.code === 'EACCES') {
-        continue;
-      } else {
-        throw err;
-      }
-    }
+    editorConfig = findInFolder(testedFolder, '.editorconfig');
   }
   if (editorConfig) {
     return editorConfig;
+  } else {
+    return null;
   }
-  return null;
 };
 
 export { checkIfKTlintExist, findEditorConfig };


### PR DESCRIPTION
Currently, the extension only checks for the `.editorconfig` file in the directory the file itself is in, which doesn't work if the file isn't in the root folder of the project. This changes it so that it will continue up the folder tree until either it finds a file named `.editorconfig` or hits the root directory.